### PR TITLE
[DPE-9537] Port main branch changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+# MySQL Point-In-Time-Recovery Helper
+
+This tool uploads [MySQL binlogs](https://dev.mysql.com/doc/refman/8.4/en/binary-log.html)
+to S3-compatible or Azure blob storage and provides point-in-time recovery capabilities
+for MySQL/PXC clusters.
+It makes use of Percona's [`binlog_utils_udf`](https://github.com/percona/percona-server/tree/8.4/components/binlog_utils_udf)
+to handle GTID sets and binary log files.
+
+It is similar to PostgreSQL's [pgBackRest](https://pgbackrest.org/) and other tools.
+
+## Features
+
+- **Binlog Collection**: Continuously uploads binary logs to cloud storage (S3 or Azure Blob)
+- **Point-in-Time Recovery**: Restore database to a specific timestamp, transaction, or latest state
+- **GTID-Based**: Uses [global transaction identifiers](https://dev.mysql.com/doc/refman/8.4/en/replication-gtids-concepts.html) for reliable, consistent recovery
+- **PXC Cluster Support**: Works with Percona XtraDB Cluster environments
+- **Multiple Recovery Modes**: Latest, date-based, transaction-based, or skip specific transactions
+
+## Usage
+
+### Collector
+
+```bash
+mysql-pitr-helper collect [config.yaml]
+```
+
+You can configure the collector using environment variables:
+
+**Global configurations:**
+- `HOSTS` - MySQL cluster nodes (primary nodes only)
+- `USER`, `PASS` - MySQL credentials
+- `STORAGE_TYPE` - `s3` or `azure`
+- `COLLECT_SPAN_SEC` - Collection interval (default: 60)
+- `VERIFY_TLS` - TLS verification (default: true)
+
+**Amazon S3 backend:**
+- `ENDPOINT` - S3 endpoint (default: s3.amazonaws.com)
+- `ACCESS_KEY_ID`, `SECRET_ACCESS_KEY` - AWS credentials
+- `S3_BUCKET_URL` - Bucket path (e.g., `my-bucket/backups`)
+- `DEFAULT_REGION` - AWS region
+
+**Azure Blob Storage backend:**
+- `AZURE_ENDPOINT`
+- `AZURE_CONTAINER_PATH`
+- `AZURE_STORAGE_ACCOUNT`
+- `AZURE_ACCESS_KEY`
+
+For further information, see [`collector.go`](./collector/collector.go).
+
+### Recoverer
+
+```bash
+mysql-pitr-helper recover
+```
+
+You can configure the recoverer using environment variables.
+
+**Global configurations:**
+- `HOST` - MySQL host to recover to
+- `USER`, `PASS` - MySQL credentials
+- `PITR_RECOVERY_TYPE` - Recovery mode: `latest`, `date`, `transaction`, `skip`
+- `PITR_DATE` - Target timestamp (for `date` mode): `2006-01-02 15:04:05`
+- `PITR_GTID` - GTID to restore/skip (for `transaction`/`skip` modes)
+- `STORAGE_TYPE` - `s3` or `azure`
+
+Storage credentials work similar to collector.
+
+## How it works
+
+**Collection:**
+1. Identifies healthy cluster nodes and selects the one with oldest binlogs
+2. Periodically fetches binary logs using `mysqlbinlog --raw`
+3. Uploads binlogs with GTID set metadata to cloud storage
+4. Tracks last uploaded GTID set to avoid duplicates
+
+**Recovery:**
+1. Downloads binlogs from cloud storage
+2. Filters binlogs based on current database GTID state
+3. Applies binlogs using `mysqlbinlog | mysql` pipeline
+4. Stops at specified recovery point (timestamp, GTID, or latest)
+
+## Limitations
+
+- No split-brain protection

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -80,18 +80,18 @@ type Collector struct {
 	db              *pxc.PXC
 	storage         storage.Storage
 	lastUploadedSet pxc.GTIDSet // last uploaded binary logs set
-	pxcServiceName  string      // k8s service name for PXC, its for get correct host for connection
-	pxcUser         string      // user for connection to PXC
-	pxcPass         string      // password for connection to PXC
-	gtidCacheKey    string      // filename of gtid cache json
+	hosts           []string
+	user            string // user for connection to the MySQL
+	pass            string // password for connection to the MySQL
+	gtidCacheKey    string // filename of gtid cache json
 	sourceID        string
 }
 
 type Config struct {
-	PXCServiceName     string `env:"PXC_SERVICE,required"`
-	PXCUser            string `env:"PXC_USER,required"`
-	PXCPass            string `env:"PXC_PASS,required"`
-	StorageType        string `env:"STORAGE_TYPE,required"`
+	Hosts              []string `env:"HOSTS,required"` // Only Primary cluster nodes are expected
+	User               string   `env:"USER,required"`
+	Pass               string   `env:"PASS,required"`
+	StorageType        string   `env:"STORAGE_TYPE,required"`
 	BackupStorageS3    BackupS3
 	BackupStorageAzure BackupAzure
 	BufferSize         int64   `env:"BUFFER_SIZE"`
@@ -162,21 +162,12 @@ func New(ctx context.Context, c Config) (*Collector, error) {
 		return nil, errors.New("unknown STORAGE_TYPE")
 	}
 
-	file, err := os.Open(collectorPasswordPath)
-	if err != nil {
-		return nil, errors.Wrap(err, "open file")
-	}
-	pxcPass, err := io.ReadAll(file)
-	if err != nil {
-		return nil, errors.Wrap(err, "read password")
-	}
-
 	return &Collector{
-		storage:        s,
-		pxcUser:        c.PXCUser,
-		pxcPass:        string(pxcPass),
-		pxcServiceName: c.PXCServiceName,
-		gtidCacheKey:   c.GTIDCacheKey,
+		storage:      s,
+		hosts:        c.Hosts,
+		user:         c.User,
+		pass:         c.Pass,
+		gtidCacheKey: c.GTIDCacheKey,
 	}, nil
 }
 
@@ -189,12 +180,12 @@ func (c *Collector) GetGTIDCacheKey() string {
 }
 
 func (c *Collector) Init(ctx context.Context) error {
-	host, err := pxc.GetPXCFirstHost(ctx, c.pxcServiceName)
+	host, err := pxc.GetPXCOldestBinlogHost(ctx, c.hosts, c.user, c.pass)
 	if err != nil {
-		return errors.Wrap(err, "get first PXC host")
+		return errors.Wrap(err, "get host")
 	}
 
-	db, err := pxc.NewPXC(host, c.pxcUser, c.pxcPass)
+	db, err := pxc.NewPXC(host, c.user, c.pass)
 	if err != nil {
 		return errors.Wrapf(err, "new manager with host %s", host)
 	}
@@ -208,7 +199,7 @@ func (c *Collector) Init(ctx context.Context) error {
 	switch {
 	case strings.HasPrefix(version, "8.0"):
 		log.Println("creating collector functions")
-		if err := c.CreateCollectorFunctions(ctx); err != nil {
+		if err := c.CreateCollectorFunctions(ctx, c.hosts); err != nil {
 			return errors.Wrap(err, "init 8.0: create collector functions")
 		}
 	case strings.HasPrefix(version, "8.4"):
@@ -221,16 +212,9 @@ func (c *Collector) Init(ctx context.Context) error {
 	return nil
 }
 
-func (c *Collector) CreateCollectorFunctions(ctx context.Context) error {
-	nodes, err := pxc.GetNodesByServiceName(ctx, c.pxcServiceName)
-	if err != nil {
-		return errors.Wrap(err, "get nodes by service name")
-	}
-
-	create := func(node string) error {
-		nodeArr := strings.Split(node, ":")
-		host := nodeArr[0]
-		db, err := pxc.NewPXC(host, c.pxcUser, c.pxcPass)
+func (c *Collector) CreateCollectorFunctions(ctx context.Context, hosts []string) error {
+	for _, host := range hosts {
+		db, err := pxc.NewPXC(host, c.user, c.pass)
 		if err != nil {
 			return errors.Errorf("creating connection for host %s: %v", host, err)
 		}
@@ -241,15 +225,14 @@ func (c *Collector) CreateCollectorFunctions(ctx context.Context) error {
 		return nil
 	}
 
-	for _, node := range nodes {
-		if strings.Contains(node, "wsrep_ready:ON:wsrep_connected:ON:wsrep_local_state_comment:Synced:wsrep_cluster_status:Primary") {
-			if err := create(node); err != nil {
-				return err
-			}
-		}
-	}
-
 	return nil
+}
+
+func (c *Config) SetDefaults() {
+	c.BackupStorageS3.Endpoint = "s3.amazonaws.com"
+	c.CollectSpanSec = 60
+	c.VerifyTLS = true
+	c.TimeoutSeconds = 60
 }
 
 func (c *Collector) Run(ctx context.Context) error {
@@ -295,14 +278,19 @@ func (c *Collector) lastGTIDSet(ctx context.Context, suffix string) (pxc.GTIDSet
 }
 
 func (c *Collector) newDB(ctx context.Context) error {
-	host, err := pxc.GetPXCOldestBinlogHost(ctx, c.pxcServiceName, c.pxcUser, c.pxcPass)
+	healthyHosts, err := pxc.FilterHealthyClusterMembers(ctx, c.hosts, c.user, c.pass)
+	if err != nil {
+		return errors.Wrap(err, "filter healthy cluster members")
+	}
+
+	host, err := pxc.GetPXCOldestBinlogHost(ctx, healthyHosts, c.user, c.pass)
 	if err != nil {
 		return errors.Wrap(err, "get host")
 	}
 
 	log.Println("reading binlogs from pxc with hostname=", host)
 
-	c.db, err = pxc.NewPXC(host, c.pxcUser, c.pxcPass)
+	c.db, err = pxc.NewPXC(host, c.user, c.pass)
 	if err != nil {
 		return errors.Wrapf(err, "new manager with host %s", host)
 	}
@@ -707,8 +695,8 @@ func (c *Collector) manageBinlog(ctx context.Context, binlog pxc.Binlog) (err er
 	}
 
 	errBuf := &bytes.Buffer{}
-	cmd := exec.CommandContext(ctx, "mysqlbinlog", "-R", "-P", "33062", "--raw", "-h"+c.db.GetHost(), "-u"+c.pxcUser, binlog.Name)
-	cmd.Env = append(cmd.Env, "MYSQL_PWD="+c.pxcPass)
+	cmd := exec.CommandContext(ctx, "mysqlbinlog", "-R", "-P", "33062", "--raw", "-h"+c.db.GetHost(), "-u"+c.user, binlog.Name)
+	cmd.Env = append(cmd.Env, "MYSQL_PWD="+c.pass)
 	cmd.Dir = os.TempDir()
 	cmd.Stderr = errBuf
 

--- a/main.go
+++ b/main.go
@@ -168,6 +168,8 @@ func runRecoverer(ctx context.Context) {
 
 func getCollectorConfig() (collector.Config, error) {
 	cfg := collector.Config{}
+	cfg.SetDefaults()
+
 	err := env.Parse(&cfg)
 	switch cfg.StorageType {
 	case "s3":
@@ -192,16 +194,10 @@ func getRecovererConfig() (recoverer.Config, error) {
 	}
 	switch cfg.StorageType {
 	case "s3":
-		if err := env.Parse(&cfg.BackupStorageS3); err != nil {
-			return cfg, err
-		}
 		if err := env.Parse(&cfg.BinlogStorageS3); err != nil {
 			return cfg, err
 		}
 	case "azure":
-		if err := env.Parse(&cfg.BackupStorageAzure); err != nil {
-			return cfg, err
-		}
 		if err := env.Parse(&cfg.BinlogStorageAzure); err != nil {
 			return cfg, err
 		}

--- a/pxc/pxc.go
+++ b/pxc/pxc.go
@@ -6,7 +6,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"log"
-	"os/exec"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -273,6 +273,17 @@ func (p *PXC) GetBinLogLastTimestamp(ctx context.Context, binlog string) (string
 	return timestamp, nil
 }
 
+func (p *PXC) GetCurrentGTIDSet(ctx context.Context) (string, error) {
+	var result string
+	row := p.db.QueryRowContext(ctx, "SELECT @@GLOBAL.gtid_executed;")
+	err := row.Scan(&result)
+	if err != nil {
+		return "", errors.Wrap(err, "scan current gtid_executed result")
+	}
+
+	return result, nil
+}
+
 func (p *PXC) SubtractGTIDSet(ctx context.Context, set, subSet string) (string, error) {
 	var result string
 	row := p.db.QueryRowContext(ctx, "SELECT GTID_SUBTRACT(?,?)", set, subSet)
@@ -284,60 +295,70 @@ func (p *PXC) SubtractGTIDSet(ctx context.Context, set, subSet string) (string, 
 	return result, nil
 }
 
-func GetNodesByServiceName(ctx context.Context, pxcServiceName string) ([]string, error) {
-	cmd := exec.CommandContext(ctx, "/opt/percona/peer-list", "-on-start=/opt/percona/get-pxc-state.sh", "-service="+pxcServiceName)
-	out, err := cmd.CombinedOutput()
+func (p *PXC) GetHealthyClusterMembers(ctx context.Context) ([]string, error) {
+	rows, err := p.db.QueryContext(ctx, "SELECT MEMBER_HOST FROM performance_schema.replication_group_members WHERE MEMBER_STATE = 'ONLINE'")
 	if err != nil {
-		return nil, errors.Wrapf(err, "run peer-list output: %s", out)
+		return nil, errors.Wrap(err, "select replication_group_members")
 	}
-	return strings.Split(string(out), "node:"), nil
+	defer rows.Close()
+
+	var hosts []string
+	for rows.Next() {
+		var host string
+		if err = rows.Scan(&host); err != nil {
+			return nil, errors.Wrap(err, "scan host")
+		}
+		hosts = append(hosts, host)
+	}
+
+	return hosts, nil
 }
 
-func GetPXCFirstHost(ctx context.Context, pxcServiceName string) (string, error) {
-	nodes, err := GetNodesByServiceName(ctx, pxcServiceName)
-	if err != nil {
-		return "", errors.Wrap(err, "get nodes by service name")
-	}
-	sort.Strings(nodes)
-	lastHost := ""
-	for _, node := range nodes {
-		log.Printf("PXC Node: %s", node)
-		if strings.Contains(node, "wsrep_ready:ON:wsrep_connected:ON:wsrep_local_state_comment:Synced:wsrep_cluster_status:Primary") {
-			nodeArr := strings.Split(node, ":")
-			lastHost = nodeArr[0]
+func FilterHealthyClusterMembers(ctx context.Context, hosts []string, user, pass string) ([]string, error) {
+	var healthyMembers []string
+	for _, host := range hosts {
+		db, err := NewPXC(host, user, pass)
+		if err != nil {
+			log.Printf("ERROR: creating connection for host %s: %v", host, err)
+			continue
+		}
+		healthyMembers, err = db.GetHealthyClusterMembers(ctx)
+		db.Close()
+		if err != nil {
+			log.Printf("ERROR: get healthy cluster members for host %s: %v", host, err)
+			continue
+		}
+		if len(healthyMembers) != 0 {
 			break
 		}
 	}
-	if len(lastHost) == 0 {
-		return "", errors.New("can't find host")
+	if len(healthyMembers) == 0 {
+		return nil, errors.New("no healthy cluster members detected")
 	}
-
-	log.Printf("connecting to %s", lastHost)
-
-	return lastHost, nil
+	var healthyHosts []string
+	for _, host := range hosts {
+		if slices.Contains(healthyMembers, host) {
+			healthyHosts = append(healthyHosts, host)
+		}
+	}
+	if len(healthyHosts) == 0 {
+		return nil, errors.New("no healthy cluster members found in provided hosts")
+	}
+	return healthyHosts, nil
 }
 
-func GetPXCOldestBinlogHost(ctx context.Context, pxcServiceName, user, pass string) (string, error) {
-	nodes, err := GetNodesByServiceName(ctx, pxcServiceName)
-	if err != nil {
-		return "", errors.Wrap(err, "get nodes by service name")
-	}
-
+func GetPXCOldestBinlogHost(ctx context.Context, hosts []string, user, pass string) (string, error) {
 	var oldestHost string
 	var oldestTS int64
-	for _, node := range nodes {
-		if strings.Contains(node, "wsrep_ready:ON:wsrep_connected:ON:wsrep_local_state_comment:Synced:wsrep_cluster_status:Primary") {
-			nodeArr := strings.Split(node, ":")
-			binlogTime, err := getBinlogTime(ctx, nodeArr[0], user, pass)
-			if err != nil {
-				log.Printf("ERROR: get binlog time: %v", err)
-				continue
-			}
-			if len(oldestHost) == 0 || oldestTS > 0 && binlogTime < oldestTS {
-				oldestHost = nodeArr[0]
-				oldestTS = binlogTime
-			}
-
+	for _, host := range hosts {
+		binlogTime, err := getBinlogTime(ctx, host, user, pass)
+		if err != nil {
+			log.Printf("ERROR: get binlog time %v", err)
+			continue
+		}
+		if len(oldestHost) == 0 || oldestTS > 0 && binlogTime < oldestTS {
+			oldestHost = host
+			oldestTS = binlogTime
 		}
 	}
 

--- a/recoverer/recoverer.go
+++ b/recoverer/recoverer.go
@@ -3,14 +3,12 @@ package recoverer
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"log"
 	"net/url"
 	"os"
 	"os/exec"
 	"path"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -26,10 +24,10 @@ type Recoverer struct {
 	db             *pxc.PXC
 	recoverTime    string
 	storage        storage.Storage
-	pxcUser        string
-	pxcPass        string
+	host           string
+	user           string
+	pass           string
 	recoverType    RecoverType
-	pxcServiceName string
 	binlogs        []string
 	gtidSet        string
 	startGTID      string
@@ -40,11 +38,9 @@ type Recoverer struct {
 }
 
 type Config struct {
-	PXCServiceName     string `env:"PXC_SERVICE,required"`
-	PXCUser            string `env:"PXC_USER,required"`
-	PXCPass            string `env:"PXC_PASS,required"`
-	BackupStorageS3    BackupS3
-	BackupStorageAzure BackupAzure
+	Host               string `env:"HOST,required"`
+	User               string `env:"USER,required"`
+	Pass               string `env:"PASS,required"`
 	RecoverTime        string `env:"PITR_DATE"`
 	RecoverType        string `env:"PITR_RECOVERY_TYPE,required"`
 	GTID               string `env:"PITR_GTID"`
@@ -54,68 +50,36 @@ type Config struct {
 	BinlogStorageAzure BinlogAzure
 }
 
-func (c Config) storages(ctx context.Context) (storage.Storage, storage.Storage, error) {
-	var binlogStorage, defaultStorage storage.Storage
+func (c Config) storage(ctx context.Context) (storage.Storage, error) {
+	var binlogStorage storage.Storage
 	switch c.StorageType {
 	case "s3":
 		bucket, prefix, err := getBucketAndPrefix(c.BinlogStorageS3.BucketURL)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "get bucket and prefix")
+			return nil, errors.Wrap(err, "get bucket and prefix")
 		}
 
 		// try to read the S3 CA bundle
 		caBundle, err := os.ReadFile(path.Join(naming.BackupStorageCAFileDirectory, naming.BackupStorageCAFileName))
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
-			return nil, nil, errors.Wrap(err, "read CA bundle file")
+			return nil, errors.Wrap(err, "read CA bundle file")
 		}
 
 		binlogStorage, err = storage.NewS3(ctx, c.BinlogStorageS3.Endpoint, c.BinlogStorageS3.AccessKeyID, c.BinlogStorageS3.AccessKey, bucket, prefix, c.BinlogStorageS3.Region, c.VerifyTLS, caBundle)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "new s3 storage")
-		}
-
-		bucket, prefix, err = getBucketAndPrefix(c.BackupStorageS3.BackupDest)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "get bucket and prefix")
-		}
-		defaultStorage, err = storage.NewS3(ctx, c.BackupStorageS3.Endpoint, c.BackupStorageS3.AccessKeyID, c.BackupStorageS3.AccessKey, bucket, prefix, c.BackupStorageS3.Region, c.VerifyTLS, caBundle)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "new storage manager")
+			return nil, errors.Wrap(err, "new s3 storage")
 		}
 	case "azure":
 		var err error
 		container, prefix := getContainerAndPrefix(c.BinlogStorageAzure.ContainerPath)
 		binlogStorage, err = storage.NewAzure(c.BinlogStorageAzure.AccountName, c.BinlogStorageAzure.AccountKey, c.BinlogStorageAzure.Endpoint, container, prefix, c.BinlogStorageAzure.BlockSize, c.BinlogStorageAzure.Concurrency)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "new azure storage")
-		}
-		defaultStorage, err = storage.NewAzure(c.BackupStorageAzure.AccountName, c.BackupStorageAzure.AccountKey, c.BackupStorageAzure.Endpoint, c.BackupStorageAzure.ContainerName, c.BackupStorageAzure.BackupDest, c.BackupStorageAzure.BlockSize, c.BackupStorageAzure.Concurrency)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "new azure storage")
+			return nil, errors.Wrap(err, "new azure storage")
 		}
 	default:
-		return nil, nil, errors.New("unknown STORAGE_TYPE")
+		return nil, errors.New("unknown STORAGE_TYPE")
 	}
-	return binlogStorage, defaultStorage, nil
-}
-
-type BackupS3 struct {
-	Endpoint    string `env:"ENDPOINT" envDefault:"s3.amazonaws.com"`
-	AccessKeyID string `env:"ACCESS_KEY_ID,required"`
-	AccessKey   string `env:"SECRET_ACCESS_KEY,required"`
-	Region      string `env:"DEFAULT_REGION,required"`
-	BackupDest  string `env:"S3_BUCKET_URL,required"`
-}
-
-type BackupAzure struct {
-	Endpoint      string `env:"AZURE_ENDPOINT,required"`
-	ContainerName string `env:"AZURE_CONTAINER_NAME,required"`
-	StorageClass  string `env:"AZURE_STORAGE_CLASS"`
-	AccountName   string `env:"AZURE_STORAGE_ACCOUNT,required"`
-	AccountKey    string `env:"AZURE_ACCESS_KEY,required"`
-	BackupDest    string `env:"BACKUP_PATH,required"`
-	BlockSize     int64  `env:"AZURE_BLOCK_SIZE"`
-	Concurrency   int    `env:"AZURE_CONCURRENCY"`
+	return binlogStorage, nil
 }
 
 type BinlogS3 struct {
@@ -137,9 +101,6 @@ type BinlogAzure struct {
 }
 
 func (c *Config) Verify() {
-	if len(c.BackupStorageS3.Endpoint) == 0 {
-		c.BackupStorageS3.Endpoint = "s3.amazonaws.com"
-	}
 	if len(c.BinlogStorageS3.Endpoint) == 0 {
 		c.BinlogStorageS3.Endpoint = "s3.amazonaws.com"
 	}
@@ -152,53 +113,20 @@ func New(ctx context.Context, c Config) (*Recoverer, error) {
 
 	log.Printf("starting point-in-time-recovery, type: %s", c.RecoverType)
 
-	binlogStorage, storage, err := c.storages(ctx)
+	binlogStorage, err := c.storage(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "new binlog storage manager")
 	}
 
-	startGTID, err := getStartGTIDSet(ctx, storage)
-	if err != nil {
-		return nil, errors.Wrap(err, "get start GTID")
-	}
-	log.Printf("last uploaded GTID set: %s", startGTID)
-
-	if c.RecoverType == string(Transaction) {
-		log.Printf("target GTID: %s", c.GTID)
-
-		gtidSplitted := strings.Split(startGTID, ":")
-		if len(gtidSplitted) != 2 {
-			return nil, errors.New("Invalid start gtidset provided")
-		}
-		lastSetIdx := 1
-		setSplitted := strings.Split(gtidSplitted[1], "-")
-		if len(setSplitted) == 1 {
-			lastSetIdx = 0
-		}
-		lastSet := setSplitted[lastSetIdx]
-		lastSetInt, err := strconv.ParseInt(lastSet, 10, 64)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to cast last set value to in")
-		}
-		transactionNum, err := strconv.ParseInt(strings.Split(c.GTID, ":")[1], 10, 64)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to parse transaction num to restore")
-		}
-		if transactionNum < lastSetInt {
-			return nil, errors.New("Can't restore to transaction before backup")
-		}
-	}
-
 	return &Recoverer{
-		storage:        binlogStorage,
-		recoverTime:    c.RecoverTime,
-		pxcUser:        c.PXCUser,
-		pxcPass:        c.PXCPass,
-		pxcServiceName: c.PXCServiceName,
-		recoverType:    RecoverType(c.RecoverType),
-		startGTID:      startGTID,
-		gtid:           c.GTID,
-		verifyTLS:      c.VerifyTLS,
+		storage:     binlogStorage,
+		recoverTime: c.RecoverTime,
+		host:        c.Host,
+		user:        c.User,
+		pass:        c.Pass,
+		recoverType: RecoverType(c.RecoverType),
+		gtid:        c.GTID,
+		verifyTLS:   c.VerifyTLS,
 	}, nil
 }
 
@@ -244,13 +172,22 @@ const (
 )
 
 func (r *Recoverer) Run(ctx context.Context) error {
-	host, err := pxc.GetPXCFirstHost(ctx, r.pxcServiceName)
+	var err error
+	r.db, err = pxc.NewPXC(r.host, r.user, r.pass)
 	if err != nil {
-		return errors.Wrap(err, "get host")
+		return errors.Wrapf(err, "new manager with host %s", r.host)
 	}
-	r.db, err = pxc.NewPXC(host, r.pxcUser, r.pxcPass)
+
+	r.startGTID, err = r.db.GetCurrentGTIDSet(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "new manager with host %s", host)
+		return errors.Wrap(err, "get start GTID")
+	}
+
+	if r.recoverType == Transaction {
+		err = r.verifyTransactionInputGTID(ctx)
+		if err != nil {
+			return errors.Wrap(err, "verify transaction num to restore")
+		}
 	}
 
 	err = r.setBinlogs(ctx)
@@ -260,10 +197,10 @@ func (r *Recoverer) Run(ctx context.Context) error {
 
 	switch r.recoverType {
 	case Skip:
-		r.recoverFlag = "--exclude-gtids=" + r.gtid
+		r.recoverFlag = `--exclude-gtids="` + r.gtid + `"`
 		log.Printf("recovery type: %s, gtid: %s", Skip, r.gtid)
 	case Transaction:
-		r.recoverFlag = "--exclude-gtids=" + r.gtidSet
+		r.recoverFlag = `--exclude-gtids="` + r.gtidSet + `"`
 		log.Printf("recovery type: %s, gtid set: %s", Transaction, r.gtidSet)
 	case Date:
 		r.recoverFlag = `--stop-datetime="` + r.recoverTime + `"`
@@ -308,7 +245,7 @@ func (r *Recoverer) recover(ctx context.Context) (err error) {
 		}
 	}
 
-	err = os.Setenv("MYSQL_PWD", os.Getenv("PXC_PASS"))
+	err = os.Setenv("MYSQL_PWD", r.pass)
 	if err != nil {
 		return errors.Wrap(err, "set mysql pwd env var")
 	}
@@ -316,7 +253,7 @@ func (r *Recoverer) recover(ctx context.Context) (err error) {
 	mysqlStdin, binlogStdout := io.Pipe()
 	defer mysqlStdin.Close()
 
-	mysqlCmd := exec.CommandContext(ctx, "mysql", "-h", r.db.GetHost(), "-P", "33062", "-u", r.pxcUser)
+	mysqlCmd := exec.CommandContext(ctx, "mysql", "-h", r.db.GetHost(), "-P", "33062", "-u", r.user)
 	log.Printf("Running %s", mysqlCmd.String())
 	mysqlCmd.Stdin = mysqlStdin
 	mysqlCmd.Stderr = os.Stderr
@@ -413,7 +350,6 @@ func (r *Recoverer) setBinlogs(ctx context.Context) error {
 	}
 	reverse(list)
 	binlogs := []string{}
-	sourceID := strings.Split(r.startGTID, ":")[0]
 	log.Println("current gtid set is", r.startGTID)
 	for _, binlog := range list {
 		if strings.Contains(binlog, "-gtid-set") {
@@ -459,11 +395,26 @@ func (r *Recoverer) setBinlogs(ctx context.Context) error {
 		}
 	}
 	if len(binlogs) == 0 {
-		return errors.Errorf("no objects for prefix binlog_ or with source_id=%s", sourceID)
+		return errors.Errorf("no objects for prefix binlog_ or with gtid=%s", r.gtid)
 	}
 	reverse(binlogs)
 	r.binlogs = binlogs
 
+	return nil
+}
+
+func (r *Recoverer) verifyTransactionInputGTID(ctx context.Context) error {
+	gtidSplit := strings.Split(r.gtid, ":")
+	if len(gtidSplit) != 2 || strings.Contains(gtidSplit[1], "-") {
+		return errors.New("bad transaction num format")
+	}
+	subResult, err := r.db.SubtractGTIDSet(ctx, r.startGTID, r.gtid)
+	if err != nil {
+		return errors.Wrap(err, "transaction num is malformed or gtid subtract query exception occurred")
+	}
+	if subResult != r.startGTID {
+		return errors.New("can't restore to the transaction before backup")
+	}
 	return nil
 }
 
@@ -498,158 +449,4 @@ func reverse(list []string) {
 		opp := len(list) - 1 - i
 		list[i], list[opp] = list[opp], list[i]
 	}
-}
-
-func getStartGTIDSet(ctx context.Context, s storage.Storage) (string, error) {
-	currGTID, err := getGTID(ctx, s)
-	if err != nil {
-		return "", errors.Wrapf(err, "get gtid")
-	}
-
-	xbInfoContent, err := getXtrabackupInfo(ctx, s)
-	if err != nil {
-		return "", errors.Wrapf(err, "get xtrabackup info")
-	}
-
-	set, err := getSetFromXtrabackupInfo(currGTID, xbInfoContent)
-	if err != nil {
-		return "", errors.Wrapf(err, "get set from xtrabackup info")
-	}
-	return fmt.Sprintf("%s:%s", currGTID, set), nil
-}
-
-func getXtrabackupInfo(ctx context.Context, s storage.Storage) ([]byte, error) {
-	xbInfo, err := s.ListObjects(ctx, "xtrabackup_info")
-	if err != nil {
-		return nil, errors.Wrapf(err, "list xtrabackup_info objects")
-	}
-	if len(xbInfo) == 0 {
-		return nil, errors.New("no xtrabackup_info objects found")
-	}
-	sort.Strings(xbInfo)
-	xbInfoObj, err := s.GetObject(ctx, xbInfo[0])
-	if err != nil {
-		return nil, errors.Wrapf(err, "get xtrabackup_info object")
-	}
-	xbInfoContent, err := getDecompressedContent(ctx, xbInfoObj, "xtrabackup_info")
-	if err != nil {
-		return nil, errors.Wrapf(err, "get decompressed content for xtrabackup_info")
-	}
-	return xbInfoContent, nil
-}
-
-func getGTID(ctx context.Context, s storage.Storage) (string, error) {
-	sstInfo, err := s.ListObjects(ctx, ".sst_info/sst_info")
-	if err != nil {
-		return "", errors.Wrapf(err, "list sst_info objects objects")
-	}
-	if len(sstInfo) > 0 {
-		sort.Strings(sstInfo)
-		return getGTIDFromSSTInfo(ctx, sstInfo[0], s)
-	}
-
-	xbBinlogInfo, err := s.ListObjects(ctx, "xtrabackup_binlog_info")
-	if err != nil {
-		return "", errors.Wrapf(err, "list xtrabackup_binlog_info objects")
-	}
-	if len(xbBinlogInfo) > 0 {
-		sort.Strings(xbBinlogInfo)
-		return getGTIDFromXtrabackupBinlogInfo(ctx, xbBinlogInfo[0], s)
-	}
-	return "", errors.New("no sst_info or xtrabackup_binlog_info objects found")
-}
-
-func getGTIDFromSSTInfo(
-	ctx context.Context,
-	sstInfoFile string,
-	s storage.Storage) (string, error) {
-	sstInfoObj, err := s.GetObject(ctx, sstInfoFile)
-	if err != nil {
-		return "", errors.Wrapf(err, "get sst_info object")
-	}
-	sstContent, err := getDecompressedContent(ctx, sstInfoObj, "sst_info")
-	if err != nil {
-		return "", errors.Wrapf(err, "get decompressed content for sst_info")
-	}
-
-	gtidSet, err := parseGTIDFromSSTInfoContent(sstContent)
-	if err != nil {
-		return "", errors.Wrapf(err, "parse gtid from sst_info content")
-	}
-
-	return strings.Split(gtidSet, ":")[0], nil
-}
-
-func parseGTIDFromSSTInfoContent(content []byte) (string, error) {
-	sep := []byte("galera-gtid=")
-	startIndex := bytes.Index(content, sep)
-	if startIndex == -1 {
-		return "", errors.New("no gtid data in backup")
-	}
-	newOut := content[startIndex+len(sep):]
-	e := bytes.Index(newOut, []byte("\n"))
-	if e == -1 {
-		return "", errors.New("can't find gtid data in backup")
-	}
-	return string(newOut[:e]), nil
-}
-
-func getGTIDFromXtrabackupBinlogInfo(ctx context.Context, xbBinlogInfoFile string, s storage.Storage) (string, error) {
-	xbBinlogInfoObj, err := s.GetObject(ctx, xbBinlogInfoFile)
-	if err != nil {
-		return "", errors.Wrapf(err, "get xtrabackup_binlog_info object")
-	}
-
-	xbBinlogInfoContent, err := getDecompressedContent(ctx, xbBinlogInfoObj, "xtrabackup_binlog_info")
-	if err != nil {
-		return "", errors.Wrapf(err, "get decompressed content for xtrabackup_binlog_info")
-	}
-
-	gtidSet, err := parseGTIDFromXtrabackupBinlogInfoContent(xbBinlogInfoContent)
-	if err != nil {
-		return "", errors.Wrapf(err, "parse gtid from xtrabackup_binlog_info content")
-	}
-
-	return strings.Split(gtidSet, ":")[0], nil
-}
-
-func parseGTIDFromXtrabackupBinlogInfoContent(content []byte) (string, error) {
-	contentStr := string(content)
-	tokens := strings.Split(contentStr, "\t")
-	if len(tokens) != 3 {
-		return "", errors.New("incorrect number of tokens in xtrabackup_binlog_info content")
-	}
-	return tokens[2], nil
-}
-
-func getSetFromXtrabackupInfo(gtid string, xtrabackupInfo []byte) (string, error) {
-	gtids, err := getGTIDFromXtrabackup(xtrabackupInfo)
-	if err != nil {
-		return "", errors.Wrap(err, "get gtid from xtrabackup info")
-	}
-	for _, v := range strings.Split(gtids, ",") {
-		valueSplitted := strings.Split(v, ":")
-		if valueSplitted[0] == gtid {
-			return valueSplitted[1], nil
-		}
-	}
-	return "", errors.Errorf("can't find current gtid (%s) in xtrabackup file", gtid)
-}
-
-func getGTIDFromXtrabackup(content []byte) (string, error) {
-	sep := []byte("GTID of the last")
-	startIndex := bytes.Index(content, sep)
-	if startIndex == -1 {
-		return "", errors.New("no gtid data in backup")
-	}
-	newOut := content[startIndex+len(sep):]
-	e := bytes.Index(newOut, []byte("'\n"))
-	if e == -1 {
-		return "", errors.New("can't find gtid data in backup")
-	}
-
-	se := bytes.Index(newOut, []byte("'"))
-	set := newOut[se+1 : e]
-
-	return string(set), nil
 }


### PR DESCRIPTION
This PR ports the [changes](https://github.com/canonical/mysql-pitr-helper/commits?author=Zvirovyi) proposed by Vladyslav to the outdated `main` branch of this repository (8.0 exclusive support) to the upcoming upstream-updated branch (8.0 and 8.4 support).

A couple of important things here:
- I have **not** ported the YAML support, used to fetch config values from a YAML file. I could not find any code leveraging it within the charmed MySQL snap / rock, so I believe it was introduced to ease testing.
- Expend special attention to the `GetCurrentGTIDSet` function, which was introduced to replaced the `getStartGTIDSet` function as a way to get the GTID of the last executed transaction. This was done in a deliberated manner by the contractor, so I guess there is a reason for it.


### Additional changes
- Added the README file from @astrojuanlu 