### PR TITLE
[DPE-9537] Rename top-level package

### DIFF
--- a/collector/cache.go
+++ b/collector/cache.go
@@ -7,8 +7,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/backup/storage"
 	"github.com/pkg/errors"
+
+	"mysql-pitr-helper/pkg/pxc/backup/storage"
 )
 
 type BinlogCacheEntry struct {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -21,9 +21,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/unix"
 
-	"github.com/percona/percona-xtradb-cluster-operator/pkg/naming"
-	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/backup/storage"
-	"github.com/percona/percona-xtradb-cluster-operator/pxc"
+	"mysql-pitr-helper/pkg/naming"
+	"mysql-pitr-helper/pkg/pxc/backup/storage"
+	"mysql-pitr-helper/pxc"
 )
 
 const collectorPasswordPath = "/etc/mysql/mysql-users-secret/xtrabackup"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/percona/percona-xtradb-cluster-operator
+module mysql-pitr-helper
 
 go 1.25.3
 

--- a/main.go
+++ b/main.go
@@ -11,8 +11,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/percona/percona-xtradb-cluster-operator/collector"
-	"github.com/percona/percona-xtradb-cluster-operator/recoverer"
+	"mysql-pitr-helper/collector"
+	"mysql-pitr-helper/recoverer"
 
 	"github.com/caarlos0/env"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/pkg/pxc/backup/storage/options.go
+++ b/pkg/pxc/backup/storage/options.go
@@ -1,6 +1,6 @@
 package storage
 
-import api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
+import api "mysql-pitr-helper/pkg/apis/pxc/v1"
 
 type Options interface {
 	Type() api.BackupStorageType

--- a/pkg/pxc/backup/storage/storage.go
+++ b/pkg/pxc/backup/storage/storage.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pkg/errors"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
+	api "mysql-pitr-helper/pkg/apis/pxc/v1"
 )
 
 var ErrObjectNotFound = errors.New("object not found")

--- a/recoverer/recoverer.go
+++ b/recoverer/recoverer.go
@@ -13,11 +13,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/percona/percona-xtradb-cluster-operator/pkg/naming"
-	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/backup/storage"
-	"github.com/percona/percona-xtradb-cluster-operator/pxc"
-
 	"github.com/pkg/errors"
+
+	"mysql-pitr-helper/pkg/naming"
+	"mysql-pitr-helper/pkg/pxc/backup/storage"
+	"mysql-pitr-helper/pxc"
 )
 
 type Recoverer struct {


### PR DESCRIPTION
This PR renames the top-level package in `go.mod` and the source files.

Follow up to https://github.com/canonical/mysql-pitr-helper/pull/9.