### PR TITLE
[DPE-9537] Release v5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,14 @@
+mysql-pitr-helper (5-0ubuntu0.22.04.1) jammy; urgency=medium
+
+  * Fix vendored packages
+
+ -- Sinclert Perez <sinclert.perez@canonical.com>  Mon, 25 Mar 2026 17:00:00 +0100
+
 mysql-pitr-helper (4-0ubuntu0.22.04.1) jammy; urgency=medium
 
   * Golang package rename
 
- -- Sinclert Perez <sinclert.perez@canonical.com>  Mon, 23 Mar 2026 14:40:00 +0100
+ -- Sinclert Perez <sinclert.perez@canonical.com>  Mon, 25 Mar 2026 14:40:00 +0100
 
 mysql-pitr-helper (3-0ubuntu0.22.04.1) jammy; urgency=medium
 


### PR DESCRIPTION
This PR adds a new entry to the Debian changelog, so that a new released can be built and published.