### PR TITLE
[DPE-9537] Release v6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mysql-pitr-helper (6-0ubuntu0.22.04.1) jammy; urgency=medium
+
+  * Downgrade to Go 1.23
+
+ -- Sinclert Perez <sinclert.perez@canonical.com>  Mon, 26 Mar 2026 12:15:00 +0100
+
 mysql-pitr-helper (5-0ubuntu0.22.04.1) jammy; urgency=medium
 
   * Fix vendored packages


### PR DESCRIPTION
This PR adds a new entry to the Debian changelog, so that a new released can be built and published.